### PR TITLE
增加 findAll() 以及調整 findByRange() 回傳型態

### DIFF
--- a/library/src/main/java/com/dtc/fhir/gwt/extension/PageResult.java
+++ b/library/src/main/java/com/dtc/fhir/gwt/extension/PageResult.java
@@ -1,21 +1,20 @@
 package com.dtc.fhir.gwt.extension;
 
-import java.util.List;
+import java.io.Serializable;
 
-public class PageResult<T> {
-	
+public class PageResult implements Serializable {
+	private static final long serialVersionUID = 1L;
+
 	private int total;
-	
 	private String code;
-	
-	List<T> results;
-	
-	public PageResult(int total, String code, List<T> results) {
+
+	PageResult() {}	//Just for GWT RPC
+
+	public PageResult(int total, String code) {
 		this.total = total;
-		this.results = results;
 		this.code = code;
 	}
-	
+
 	// Getter & Setter
 	public int getTotal() {
 		return total;
@@ -28,11 +27,5 @@ public class PageResult<T> {
 	}
 	public void setCode(String code) {
 		this.code = code;
-	}
-	public List<T> getResults() {
-		return results;
-	}
-	public void setResults(List<T> results) {
-		this.results = results;
 	}
 }

--- a/library/src/main/java/com/dtc/fhir/gwt/extension/SearchResult.java
+++ b/library/src/main/java/com/dtc/fhir/gwt/extension/SearchResult.java
@@ -2,15 +2,15 @@ package com.dtc.fhir.gwt.extension;
 
 import java.io.Serializable;
 
-public class PageResult implements Serializable {
+public class SearchResult implements Serializable {
 	private static final long serialVersionUID = 1L;
 
 	private int total;
 	private String code;
 
-	PageResult() {}	//Just for GWT RPC
+	SearchResult() {}	//Just for GWT RPC
 
-	public PageResult(int total, String code) {
+	public SearchResult(int total, String code) {
 		this.total = total;
 		this.code = code;
 	}

--- a/library/src/main/java/com/dtc/fhir/repository/gwt/BaseGwtRepo.java
+++ b/library/src/main/java/com/dtc/fhir/repository/gwt/BaseGwtRepo.java
@@ -82,7 +82,7 @@ public abstract class BaseGwtRepo<T extends Resource> extends BaseRepo {
 	}
 
 	/**
-	 * @param code 
+	 * @param code
 	 * 	需先使用 {@link #getSearchResult(String)} 取得 {@link PageResult}，
 	 * 	再以 {@link PageResult#getCode()} 作為傳入值。
 	 * 	允許是 null，會得到空的 {@link List}
@@ -148,7 +148,7 @@ public abstract class BaseGwtRepo<T extends Resource> extends BaseRepo {
 	/**
 	 * @return 該次 searchPath 的結果。如果是 null 表示
 	 */
-	protected PageResult<T> getSearchResult(String searchPath) {
+	protected PageResult getSearchResult(String searchPath) {
 		Bundle bundle = GwtUnmarshaller.unmarshal(Bundle.class, fetch(searchPath));
 
 		if (bundle == null) { return null; }
@@ -165,7 +165,7 @@ public abstract class BaseGwtRepo<T extends Resource> extends BaseRepo {
 		}
 
 		//Refactory 拔掉最後一個參數
-		return new PageResult<T>(bundle.getTotal().getValue().intValue(), code, null);
+		return new PageResult(bundle.getTotal().getValue().intValue(), code);
 	}
 
 	public boolean delete(T resource) {

--- a/library/src/main/java/com/dtc/fhir/repository/gwt/BaseGwtRepo.java
+++ b/library/src/main/java/com/dtc/fhir/repository/gwt/BaseGwtRepo.java
@@ -15,7 +15,7 @@ import com.dtc.fhir.gwt.Id;
 import com.dtc.fhir.gwt.ListDt;
 import com.dtc.fhir.gwt.Resource;
 import com.dtc.fhir.gwt.ResourceContainer;
-import com.dtc.fhir.gwt.extension.PageResult;
+import com.dtc.fhir.gwt.extension.SearchResult;
 import com.dtc.fhir.gwt.util.ReferenceUtil;
 import com.dtc.fhir.repository.BaseRepo;
 import com.dtc.fhir.repository.Constant;
@@ -83,8 +83,8 @@ public abstract class BaseGwtRepo<T extends Resource> extends BaseRepo {
 
 	/**
 	 * @param code
-	 * 	需先使用 {@link #getSearchResult(String)} 取得 {@link PageResult}，
-	 * 	再以 {@link PageResult#getCode()} 作為傳入值。
+	 * 	需先使用 {@link #getSearchResult(String)} 取得 {@link SearchResult}，
+	 * 	再以 {@link SearchResult#getCode()} 作為傳入值。
 	 * 	允許是 null，會得到空的 {@link List}
 	 * @param startIndex 資料起始位置
 	 * @param amount 預計撈回的資料總量，不得超過 {@link Constant#FHIR_COUNT_LIMIT}
@@ -148,7 +148,7 @@ public abstract class BaseGwtRepo<T extends Resource> extends BaseRepo {
 	/**
 	 * @return 該次 searchPath 的結果。如果是 null 表示
 	 */
-	protected PageResult getSearchResult(String searchPath) {
+	protected SearchResult getSearchResult(String searchPath) {
 		Bundle bundle = GwtUnmarshaller.unmarshal(Bundle.class, fetch(searchPath));
 
 		if (bundle == null) { return null; }
@@ -164,8 +164,7 @@ public abstract class BaseGwtRepo<T extends Resource> extends BaseRepo {
 			}
 		}
 
-		//Refactory 拔掉最後一個參數
-		return new PageResult(bundle.getTotal().getValue().intValue(), code);
+		return new SearchResult(bundle.getTotal().getValue().intValue(), code);
 	}
 
 	public boolean delete(T resource) {

--- a/library/src/main/java/com/dtc/fhir/repository/gwt/BaseGwtRepo.java
+++ b/library/src/main/java/com/dtc/fhir/repository/gwt/BaseGwtRepo.java
@@ -146,7 +146,10 @@ public abstract class BaseGwtRepo<T extends Resource> extends BaseRepo {
 	}
 
 	/**
-	 * @return 該次 searchPath 的結果。如果是 null 表示
+	 * @return 該次 searchPath 的結果。
+	 * 	如果是 null 表示該次 search 有問題，無法解析 FHIR 回傳結果。
+	 * 	如果不是 null 而 {@link SearchResult#getCode()} 為 null，
+	 * 	則表示 search 結果資料筆數未達指定數量（aka 不滿一頁）。
 	 */
 	protected SearchResult getSearchResult(String searchPath) {
 		Bundle bundle = GwtUnmarshaller.unmarshal(Bundle.class, fetch(searchPath));


### PR DESCRIPTION
一開始是針對 #16 ，改完之後發現需要 refactor

### 預防甚於治療 ###
* `searchAndExpand()` 跟 `getSearchResult()` 是故意開成 `protected` 的，因為我認為「組 `searchPath`」是 repo 的責任，而不是 repo caller 的責任
* 理論上會希望類似的 method 排在附近（然後也希望 public 都在前面，依 visible 程度遞減，不過這有時候反而更難讀），之前沒有抓這點，這次也算大改，所以 `findByRange()` 就順便搬家了